### PR TITLE
Upgrade Minio Admin API v2 -> v3: remove base64 decode policy payload

### DIFF
--- a/src/app/policies/policies.component.ts
+++ b/src/app/policies/policies.component.ts
@@ -360,7 +360,7 @@ export class PoliciesComponent implements OnInit {
       this.apiService.validateAuthInResponse(data)
       console.log(data);
       this.policiesRaw = data;
-      const arrayOfPolicies = Object.entries(data).map((e) => ( { [e[0]]: this.b64unpack(e[1]) } ));
+      const arrayOfPolicies = Object.entries(data).map((e) => ( { [e[0]]: e[1] } ));
       this.policies = arrayOfPolicies;
       this.mdbTable.setDataSource(arrayOfPolicies);
       console.log(arrayOfPolicies)
@@ -386,11 +386,6 @@ export class PoliciesComponent implements OnInit {
     console.log("theJSON>>>>>>>>>>>",theJSON);
     var uri = this.sanitizer.bypassSecurityTrustUrl("data:text/json;charset=UTF-8," + encodeURIComponent(theJSON));
     this.downloadJsonHref = uri;
-  }
-
-  public b64unpack(str){
-    // console.log(JSON.parse(atob(str)))
-  	return JSON.parse(atob(str));
   }
 
   private rawPrepare(obj){
@@ -568,7 +563,7 @@ export class PoliciesComponent implements OnInit {
     this.resetPloicyForm(false)
     this.newPolicy.name = policy;
 
-    var oldPolicy = this.b64unpack(this.policiesRaw[policy])
+    var oldPolicy = this.policiesRaw[policy]
     this.newPolicyRaw.Statement = oldPolicy.Statement;
   }
 


### PR DESCRIPTION
Hi everyone,

Motivation:
depend: https://github.com/rzrbld/adminio-api/pull/10

Since RELEASE.2020-04-10T03-34-42Z madmin api are upgraded:
https://github.com/minio/minio/commit/2642e12d14fe6a3af53d46b0996603a6786a988b#diff-ee227e28a6bd9c2ffe47eb15033cdc2eR477
https://github.com/minio/minio/commit/2642e12d14fe6a3af53d46b0996603a6786a988b#diff-f84da3b3655cf26658302b676b19873bR112

@rzrbld If you create a new release you can udpdate Minio Server version in Dockerfile: 

```diff
- image: minio/minio:RELEASE.2020-04-04T05-39-31Z
+ image: minio/minio:RELEASE.2020-04-23T00-58-49Z
```
