### PR TITLE
Fix typo in docker-stack.yml

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -15,7 +15,6 @@ services:
         traefik.frontend.rule: "Host:adminio-host.example.org; PathPrefix:/api"
         traefik.port: '8080'
     environment:
-      ADMINIO_BACKENDS: '[{"name":"foo","url":"http://localhost:8080"}]'
       ADMINIO_HOST_PORT: 0.0.0.0:8080
       MINIO_ACCESS: PLZ_CHANGE_access_key
       MINIO_HOST_PORT: PLZ_CHANGE_minio_server:443
@@ -36,6 +35,7 @@ services:
       ADMINIO_MULTI_BACKEND: "false"
       ADMINIO_PROD: "true"
       API_BASE_URL: https://adminio-host.example.org
+      ADMINIO_BACKENDS: '[{"name":"foo","url":"http://localhost:8080"}]'
     image: rzrbld/adminio-ui:latest
     networks:
       - public


### PR DESCRIPTION
According to documentation ENV - "ADMINIO_BACKENDS" configure Admin backend on UI part, and not connected to API